### PR TITLE
feat: add light/dark mode icons and extension download in dashboard

### DIFF
--- a/apps/extension/assets/icon-dark.svg
+++ b/apps/extension/assets/icon-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#6366f1"/>
+  <text x="256" y="340" font-family="system-ui, sans-serif" font-size="280" font-weight="bold" fill="white" text-anchor="middle">K</text>
+</svg>

--- a/apps/extension/assets/icon-light.svg
+++ b/apps/extension/assets/icon-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#ffffff" stroke="#e5e7eb" stroke-width="8"/>
+  <text x="256" y="340" font-family="system-ui, sans-serif" font-size="280" font-weight="bold" fill="#6366f1" text-anchor="middle">K</text>
+</svg>

--- a/apps/extension/contents/nudge-overlay.tsx
+++ b/apps/extension/contents/nudge-overlay.tsx
@@ -244,14 +244,22 @@ function NudgeOverlay() {
             justifyContent: "center",
             flexShrink: 0,
           }}>
-          <span style={{ fontSize: "18px" }}>
-            {nudge.type === "doomscroll" && "🌀"}
-            {nudge.type === "distraction" && "📱"}
-            {nudge.type === "break" && "☕"}
-            {nudge.type === "focus_drift" && "🎯"}
-            {nudge.type === "encouragement" && "🌟"}
-            {nudge.type === "all_clear" && "✅"}
-          </span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+            style={{ width: "22px", height: "22px" }}>
+            <rect width="512" height="512" rx="64" fill={colors.icon} />
+            <text
+              x="256"
+              y="340"
+              fontFamily="system-ui, sans-serif"
+              fontSize="280"
+              fontWeight="bold"
+              fill="white"
+              textAnchor="middle">
+              K
+            </text>
+          </svg>
         </div>
         <div style={{ flex: 1 }}>
           <div

--- a/apps/web/public/favicon-dark.svg
+++ b/apps/web/public/favicon-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#6366f1"/>
+  <text x="256" y="340" font-family="system-ui, sans-serif" font-size="280" font-weight="bold" fill="white" text-anchor="middle">K</text>
+</svg>

--- a/apps/web/public/favicon-light.svg
+++ b/apps/web/public/favicon-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#ffffff" stroke="#e5e7eb" stroke-width="8"/>
+  <text x="256" y="340" font-family="system-ui, sans-serif" font-size="280" font-weight="bold" fill="#6366f1" text-anchor="middle">K</text>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,8 @@ export const metadata: Metadata = {
   description: "Kaizen Web App",
   icons: {
     icon: [
+      { url: "/favicon-light.svg", type: "image/svg+xml", media: "(prefers-color-scheme: light)" },
+      { url: "/favicon-dark.svg", type: "image/svg+xml", media: "(prefers-color-scheme: dark)" },
       { url: "/favicon.png", sizes: "32x32", type: "image/png" },
       { url: "/favicon-192.png", sizes: "192x192", type: "image/png" },
       { url: "/favicon-512.png", sizes: "512x512", type: "image/png" },

--- a/apps/web/src/components/dashboard.tsx
+++ b/apps/web/src/components/dashboard.tsx
@@ -66,6 +66,8 @@ import {
   RefreshCw,
   Heart,
   User as UserIcon,
+  FolderOpen,
+  CheckCircle,
 } from "lucide-react";
 
 const PROVIDER_LABELS: Record<LLMProviderType, string> = {
@@ -242,6 +244,9 @@ export function Dashboard({ initialTab }: DashboardProps) {
   // Focus history state
   const [focusHistory, setFocusHistory] = useState<Focus[] | null>(null);
   const [focusHistoryLoading, setFocusHistoryLoading] = useState(false);
+
+  // Extension install modal state
+  const [showInstallModal, setShowInstallModal] = useState(false);
 
   // Chat sidebar state
   const [chatSidebarCollapsed, setChatSidebarCollapsed] = useState(false);
@@ -589,6 +594,11 @@ export function Dashboard({ initialTab }: DashboardProps) {
     } catch (err) {
       console.error("Update theme error:", err);
     }
+  };
+
+  const handleDownloadExtension = () => {
+    window.location.href = `${apiUrl}/extension/download`;
+    setShowInstallModal(true);
   };
 
   const handleSettingsToggle = async (key: keyof UserSettings) => {
@@ -2371,7 +2381,7 @@ export function Dashboard({ initialTab }: DashboardProps) {
 
       {/* Status Bar */}
       <footer className="fixed bottom-0 left-0 right-0 h-8 bg-muted/50 border-t border-border/40 z-40">
-        <div className="max-w-6xl mx-auto px-6 h-full flex items-center">
+        <div className="max-w-6xl mx-auto px-6 h-full flex items-center justify-between">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <div
               className={`w-1.5 h-1.5 rounded-full ${time ? "bg-accent" : "bg-muted-foreground"}`}
@@ -2389,8 +2399,104 @@ export function Dashboard({ initialTab }: DashboardProps) {
             </span>
             <span className="text-muted-foreground/50">Server Time</span>
           </div>
+          <button
+            onClick={handleDownloadExtension}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Download className="w-3 h-3" />
+            <span>Download Extension</span>
+          </button>
         </div>
       </footer>
+
+      {/* Extension Install Modal */}
+      {showInstallModal && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => setShowInstallModal(false)}
+          />
+          <div className="relative bg-background border border-border rounded-2xl shadow-2xl max-w-4xl w-full">
+            <div className="flex items-center justify-between p-6 border-b border-border">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-xl bg-blue-500/20 flex items-center justify-center">
+                  <Puzzle className="w-5 h-5 text-blue-500" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-bold">Install Kaizen Extension</h2>
+                  <p className="text-sm text-muted-foreground">Follow these steps to get started</p>
+                </div>
+              </div>
+              <button
+                onClick={() => setShowInstallModal(false)}
+                className="p-2 rounded-lg hover:bg-muted transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="p-6">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div className="p-4 bg-muted/30 rounded-xl border border-border/50">
+                  <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center font-bold text-sm mb-3">
+                    1
+                  </div>
+                  <h3 className="font-semibold mb-2 text-sm">Unzip the file</h3>
+                  <p className="text-xs text-muted-foreground">
+                    Extract <code className="px-1 py-0.5 bg-muted rounded text-[10px]">kaizen-extension.zip</code> to a folder.
+                  </p>
+                </div>
+                <div className="p-4 bg-muted/30 rounded-xl border border-border/50">
+                  <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center font-bold text-sm mb-3">
+                    2
+                  </div>
+                  <h3 className="font-semibold mb-2 text-sm">Open Extensions</h3>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Go to <code className="px-1 py-0.5 bg-muted rounded text-[10px]">chrome://extensions</code>
+                  </p>
+                </div>
+                <div className="p-4 bg-muted/30 rounded-xl border border-border/50">
+                  <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center font-bold text-sm mb-3">
+                    3
+                  </div>
+                  <h3 className="font-semibold mb-2 text-sm">Developer Mode</h3>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Enable the toggle in the top-right corner.
+                  </p>
+                  <div className="flex items-center gap-1.5 p-2 bg-background rounded-lg text-xs">
+                    <Settings className="w-3 h-3 text-muted-foreground" />
+                    <span>Dev mode</span>
+                    <div className="ml-auto w-8 h-4 bg-blue-600 rounded-full relative">
+                      <div className="absolute right-0.5 top-0.5 w-3 h-3 bg-white rounded-full" />
+                    </div>
+                  </div>
+                </div>
+                <div className="p-4 bg-muted/30 rounded-xl border border-border/50">
+                  <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center font-bold text-sm mb-3">
+                    4
+                  </div>
+                  <h3 className="font-semibold mb-2 text-sm">Load Unpacked</h3>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Click the button and select the extracted folder.
+                  </p>
+                  <div className="inline-flex items-center gap-1.5 px-2 py-1 bg-background rounded-lg text-xs">
+                    <FolderOpen className="w-3 h-3" />
+                    Load unpacked
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 p-4 bg-green-500/10 border border-green-500/20 rounded-xl mt-4">
+                <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0" />
+                <p className="text-sm text-green-700 dark:text-green-400">
+                  <span className="font-medium">You&apos;re all set!</span> The extension will appear in your toolbar. Click it to open the side panel!
+                </p>
+                <Button onClick={() => setShowInstallModal(false)} size="sm" className="ml-auto">
+                  Got it!
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div >
   );
 }


### PR DESCRIPTION
## Summary
- Add light and dark variants of the Kaizen K logo icon (SVG) for both extension and web app favicons
- Update web app favicon to use `prefers-color-scheme` media queries for automatic theme switching
- Replace emoji icons in nudge overlay with dynamic Kaizen K logo SVG that matches nudge type colors
- Add "Download Extension" button to dashboard status bar with installation instructions modal

## Test plan
- [ ] Verify favicon switches between light/dark based on system theme
- [ ] Check nudge overlay displays K logo instead of emoji icons
- [ ] Test "Download Extension" button in dashboard status bar triggers download and shows modal
- [ ] Verify install modal displays correctly and can be dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)