### PR TITLE
feat: Ansible deployment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ coverage
 # prisma
 *.db
 *.db-journal
+
+# deployment
+deployment/config.env
+deployment/secrets.yml

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ coverage
 # deployment
 deployment/config.env
 deployment/secrets.yml
+deployment/inventory.ini

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License Copyright (c) 2026 sandipndev
+MIT License Copyright (c) 2026 anikvox
 
 Permission is hereby granted, free of
 charge, to any person obtaining a copy of this software and associated

--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,0 +1,12 @@
+# Ignore secrets file (should be vault-encrypted before committing if needed)
+secrets.yml
+
+# Deployment config (host/user)
+config.env
+
+# Ansible retry files
+*.retry
+
+# Temporary files
+*.tmp
+*.bak

--- a/deployment/ansible.cfg
+++ b/deployment/ansible.cfg
@@ -1,9 +1,9 @@
 [defaults]
-inventory = inventory.yml
+inventory = inventory.ini
 host_key_checking = False
 timeout = 30
-stdout_callback = yaml
-callbacks_enabled = profile_tasks
+stdout_callback = ansible.builtin.default
+result_format = yaml
 
 [privilege_escalation]
 become = True

--- a/deployment/ansible.cfg
+++ b/deployment/ansible.cfg
@@ -1,0 +1,16 @@
+[defaults]
+inventory = inventory.yml
+host_key_checking = False
+timeout = 30
+stdout_callback = yaml
+callbacks_enabled = profile_tasks
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/deployment/config.env.example
+++ b/deployment/config.env.example
@@ -1,0 +1,3 @@
+# Copy this file to config.env and fill in your values
+DEPLOY_USER=your_ssh_username
+DEPLOY_HOST=your_server_ip

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -1,0 +1,166 @@
+---
+- name: Deploy Kaizen to Production
+  hosts: kaizen-prod
+  become: yes
+  vars_files:
+    - secrets.yml
+  vars:
+    app_dir: /opt/kaizen
+    repo_url: https://github.com/anikvox/kaizen.git
+    repo_branch: main
+    # Domain configuration
+    web_domain: kaizen.apps.sandipan.dev
+    api_domain: api.kaizen.apps.sandipan.dev
+    # Ports (must match reverse proxy config)
+    web_port: 60091
+    api_port: 60092
+    db_port: 60093
+    # Database
+    db_user: kaizen
+    db_password: "{{ vault_db_password }}"
+    db_name: kaizen
+
+  tasks:
+    # ============================================
+    # PHASE 1: System Setup (first-time only)
+    # ============================================
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+      tags: [setup]
+
+    - name: Install required packages
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg
+          - lsb-release
+          - git
+          - python3-pip
+        state: present
+      tags: [setup]
+
+    - name: Add Docker GPG key
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
+      tags: [setup]
+
+    - name: Add Docker repository
+      apt_repository:
+        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+      tags: [setup]
+
+    - name: Install Docker
+      apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-compose-plugin
+        state: present
+        update_cache: yes
+      tags: [setup]
+
+    - name: Start and enable Docker
+      systemd:
+        name: docker
+        state: started
+        enabled: yes
+      tags: [setup]
+
+    - name: Add user to docker group
+      user:
+        name: "{{ ansible_user }}"
+        groups: docker
+        append: yes
+      tags: [setup]
+
+    # ============================================
+    # PHASE 2: Application Deployment
+    # ============================================
+    - name: Create application directory
+      file:
+        path: "{{ app_dir }}"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0755'
+      tags: [deploy]
+
+    - name: Clone or update repository
+      git:
+        repo: "{{ repo_url }}"
+        dest: "{{ app_dir }}"
+        version: "{{ repo_branch }}"
+        force: yes
+      become_user: "{{ ansible_user }}"
+      tags: [deploy]
+
+    - name: Create .env.production file
+      template:
+        src: templates/.env.production.j2
+        dest: "{{ app_dir }}/.env.production"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0600'
+      tags: [deploy, config]
+
+    - name: Create production docker-compose file
+      template:
+        src: templates/docker-compose.prod.yml.j2
+        dest: "{{ app_dir }}/docker-compose.prod.yml"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+      tags: [deploy, config]
+
+    # ============================================
+    # PHASE 3: Build and Start Services
+    # ============================================
+    - name: Stop existing containers (if any)
+      community.docker.docker_compose_v2:
+        project_src: "{{ app_dir }}"
+        files:
+          - docker-compose.prod.yml
+        state: absent
+      become_user: "{{ ansible_user }}"
+      ignore_errors: yes
+      tags: [deploy]
+
+    - name: Build and start containers
+      community.docker.docker_compose_v2:
+        project_src: "{{ app_dir }}"
+        files:
+          - docker-compose.prod.yml
+        state: present
+        build: always
+        pull: always
+      become_user: "{{ ansible_user }}"
+      tags: [deploy]
+
+    - name: Wait for services to be healthy
+      uri:
+        url: "http://localhost:{{ api_port }}/health"
+        status_code: 200
+      register: health_check
+      until: health_check.status == 200
+      retries: 30
+      delay: 5
+      tags: [deploy]
+
+    - name: Display deployment info
+      debug:
+        msg: |
+          Deployment complete!
+
+          Web UI: https://{{ web_domain }}
+          API:    https://{{ api_domain }}
+
+          To view logs: just deploy-logs
+          To SSH:       just deploy-ssh
+      tags: [deploy]

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -122,13 +122,11 @@
     # ============================================
     # PHASE 3: Build and Start Services
     # ============================================
-    - name: Stop existing containers (if any)
-      community.docker.docker_compose_v2:
-        project_src: "{{ app_dir }}"
-        files:
-          - docker-compose.prod.yml
-        state: absent
-      become_user: "{{ ansible_user }}"
+    - name: Force cleanup existing containers
+      shell: |
+        cd {{ app_dir }}
+        docker compose -f docker-compose.prod.yml down --remove-orphans 2>/dev/null || true
+        docker rm -f kaizen-postgres kaizen-app 2>/dev/null || true
       ignore_errors: yes
       tags: [deploy]
 
@@ -140,7 +138,6 @@
         state: present
         build: always
         pull: always
-      become_user: "{{ ansible_user }}"
       tags: [deploy]
 
     - name: Wait for services to be healthy

--- a/deployment/inventory.yml
+++ b/deployment/inventory.yml
@@ -1,0 +1,6 @@
+all:
+  hosts:
+    kaizen-prod:
+      ansible_host: "{{ lookup('env', 'DEPLOY_HOST') }}"
+      ansible_user: "{{ lookup('env', 'DEPLOY_USER') }}"
+      ansible_python_interpreter: /usr/bin/python3

--- a/deployment/secrets.yml.example
+++ b/deployment/secrets.yml.example
@@ -1,0 +1,21 @@
+# Copy this file to secrets.yml and fill in the values
+# Then encrypt with: ansible-vault encrypt secrets.yml
+#
+# To edit later: ansible-vault edit secrets.yml
+# To view: ansible-vault view secrets.yml
+
+# Database
+vault_db_password: "your_secure_database_password"
+
+# Clerk Authentication (use live keys from .env.production)
+vault_clerk_publishable_key: "pk_live_..."
+vault_clerk_secret_key: "sk_live_..."
+
+# AI API Keys
+vault_gemini_api_key: "AIza..."
+vault_opik_api_key: "..."
+vault_opik_workspace: "your_workspace"
+vault_opik_project_name: "project-kaizen"
+
+# Encryption
+vault_encryption_key: "your_32_char_encryption_key"

--- a/deployment/templates/docker-compose.prod.yml.j2
+++ b/deployment/templates/docker-compose.prod.yml.j2
@@ -1,0 +1,61 @@
+services:
+  app:
+    build:
+      context: .devcontainer
+      dockerfile: Dockerfile
+    container_name: kaizen-app
+    volumes:
+      - .:/src:ro
+      - workspace:/workspace
+    working_dir: /workspace
+    command: /src/.devcontainer/post-start.sh
+    env_file:
+      - .env.production
+    environment:
+      - DATABASE_URL=postgresql://{{ db_user }}:{{ db_password }}@postgres:5432/{{ db_name }}
+      - CORS_ORIGINS=https://{{ web_domain }},https://{{ api_domain }}
+      - NEXT_PUBLIC_KAIZEN_API_URL=https://{{ api_domain }}
+      - PLASMO_PUBLIC_KAIZEN_API_URL=https://{{ api_domain }}
+    ports:
+      - "{{ web_port }}:60091"
+      - "{{ api_port }}:60092"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - kaizen-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:60092/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: kaizen-postgres
+    environment:
+      POSTGRES_USER: {{ db_user }}
+      POSTGRES_PASSWORD: {{ db_password }}
+      POSTGRES_DB: {{ db_name }}
+    ports:
+      - "127.0.0.1:{{ db_port }}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U {{ db_user }} -d {{ db_name }}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - kaizen-network
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  workspace:
+
+networks:
+  kaizen-network:
+    driver: bridge

--- a/deployment/templates/docker-compose.prod.yml.j2
+++ b/deployment/templates/docker-compose.prod.yml.j2
@@ -16,6 +16,7 @@ services:
       - CORS_ORIGINS=https://{{ web_domain }},https://{{ api_domain }}
       - NEXT_PUBLIC_KAIZEN_API_URL=https://{{ api_domain }}
       - PLASMO_PUBLIC_KAIZEN_API_URL=https://{{ api_domain }}
+      - PLASMO_PUBLIC_KAIZEN_WEB_URL=https://{{ web_domain }}
     ports:
       - "{{ web_port }}:60091"
       - "{{ api_port }}:60092"

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
         just
         overmind
         tmux
+        ansible
       ];
       devEnvVars = rec {
         PRISMA_SCHEMA_ENGINE_BINARY = "${pkgs.prisma-engines_6}/bin/schema-engine";

--- a/justfile
+++ b/justfile
@@ -57,24 +57,29 @@ seed-activity:
 # Deployment Commands
 # ============================================
 
-# Helper to load deploy config
-_deploy-config := "source deployment/config.env"
-
 # Deploy to production server
 deploy:
-    cd deployment && source config.env && ansible-playbook deploy.yml
+    #!/usr/bin/env bash
+    source deployment/config.env
+    cd deployment && ansible-playbook deploy.yml --ask-become-pass
 
 # Deploy with setup (first-time only - installs Docker)
 deploy-setup:
-    cd deployment && source config.env && ansible-playbook deploy.yml --tags setup,deploy
+    #!/usr/bin/env bash
+    source deployment/config.env
+    cd deployment && ansible-playbook deploy.yml --tags setup,deploy --ask-become-pass
 
 # Deploy only (skip system setup)
 deploy-only:
-    cd deployment && source config.env && ansible-playbook deploy.yml --tags deploy
+    #!/usr/bin/env bash
+    source deployment/config.env
+    cd deployment && ansible-playbook deploy.yml --tags deploy --ask-become-pass
 
 # Update config files only
 deploy-config:
-    cd deployment && source config.env && ansible-playbook deploy.yml --tags config
+    #!/usr/bin/env bash
+    source deployment/config.env
+    cd deployment && ansible-playbook deploy.yml --tags config --ask-become-pass
 
 # View production logs
 deploy-logs:

--- a/justfile
+++ b/justfile
@@ -52,3 +52,56 @@ prompts-sync:
 # Seed fake activity data for testing focus agent
 seed-activity:
     pnpm --filter @kaizen/api seed:activity
+
+# ============================================
+# Deployment Commands
+# ============================================
+
+# Helper to load deploy config
+_deploy-config := "source deployment/config.env"
+
+# Deploy to production server
+deploy:
+    cd deployment && source config.env && ansible-playbook deploy.yml
+
+# Deploy with setup (first-time only - installs Docker)
+deploy-setup:
+    cd deployment && source config.env && ansible-playbook deploy.yml --tags setup,deploy
+
+# Deploy only (skip system setup)
+deploy-only:
+    cd deployment && source config.env && ansible-playbook deploy.yml --tags deploy
+
+# Update config files only
+deploy-config:
+    cd deployment && source config.env && ansible-playbook deploy.yml --tags config
+
+# View production logs
+deploy-logs:
+    #!/usr/bin/env bash
+    source deployment/config.env
+    ssh ${DEPLOY_USER}@${DEPLOY_HOST} "cd /opt/kaizen && docker compose -f docker-compose.prod.yml logs -f"
+
+# SSH into production server
+deploy-ssh:
+    #!/usr/bin/env bash
+    source deployment/config.env
+    ssh ${DEPLOY_USER}@${DEPLOY_HOST}
+
+# Check production service status
+deploy-status:
+    #!/usr/bin/env bash
+    source deployment/config.env
+    ssh ${DEPLOY_USER}@${DEPLOY_HOST} "cd /opt/kaizen && docker compose -f docker-compose.prod.yml ps"
+
+# Encrypt secrets file
+deploy-vault-encrypt:
+    cd deployment && ansible-vault encrypt secrets.yml
+
+# Edit encrypted secrets
+deploy-vault-edit:
+    cd deployment && ansible-vault edit secrets.yml
+
+# View encrypted secrets
+deploy-vault-view:
+    cd deployment && ansible-vault view secrets.yml


### PR DESCRIPTION
## Summary
- Add Ansible-based deployment to production server (192.168.0.98)
- Create deployment configuration with secrets management (vault-encrypted)
- Add justfile commands for deploy, logs, SSH, and vault management
- Add ansible to nix flake for dev environment

## Changes
- `deployment/deploy.yml` - Main Ansible playbook (Docker install, app deployment)
- `deployment/ansible.cfg` - Ansible configuration
- `deployment/templates/` - docker-compose and .env templates
- `deployment/secrets.yml.example` - Example secrets file
- `deployment/config.env.example` - Example host/user config
- `justfile` - Deploy commands (`just deploy`, `just deploy-logs`, etc.)
- `flake.nix` - Added ansible package

## Test plan
- [ ] Run `just deploy-setup` for first-time deployment
- [ ] Verify services are running with `just deploy-status`
- [ ] Check logs with `just deploy-logs`
- [ ] Verify web UI at https://kaizen.apps.sandipan.dev
- [ ] Verify API at https://api.kaizen.apps.sandipan.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)